### PR TITLE
Update nfts schema ver to 19 to use combined NftEvents enum

### DIFF
--- a/consumer/src/events.rs
+++ b/consumer/src/events.rs
@@ -3,7 +3,7 @@ use holaplex_hub_nfts_polygon_core::{
     db::Connection,
     proto::{
         self,
-        polygon_events::Event as PolygonEvents,
+        nft_events::Event as NftEvents,
         polygon_nft_events,
         treasury_events::{EcdsaSignature, Event as TreasuryEvents, PolygonPermitHashSignature},
         CreateEditionTransaction, MintEditionTransaction, NftEventKey, PermitArgsHash,
@@ -47,17 +47,19 @@ impl Processor {
         // match topics
         match msg {
             Services::Nfts(key, e) => match e.event {
-                Some(PolygonEvents::CreateDrop(payload)) => {
+                Some(NftEvents::PolygonCreateDrop(payload)) => {
                     self.create_polygon_edition(key, payload).await
                 },
-                Some(PolygonEvents::RetryDrop(payload)) => self.retry_drop(key, payload).await,
-                Some(PolygonEvents::MintDrop(payload)) => self.mint_drop(key, payload).await,
-                Some(PolygonEvents::UpdateDrop(payload)) => self.update_drop(key, payload).await,
-                Some(PolygonEvents::RetryMintDrop(payload)) => self.retry_mint(key, payload).await,
-                Some(PolygonEvents::TransferAsset(payload)) => {
+                Some(NftEvents::PolygonRetryDrop(payload)) => self.retry_drop(key, payload).await,
+                Some(NftEvents::PolygonMintDrop(payload)) => self.mint_drop(key, payload).await,
+                Some(NftEvents::PolygonUpdateDrop(payload)) => self.update_drop(key, payload).await,
+                Some(NftEvents::PolygonRetryMintDrop(payload)) => {
+                    self.retry_mint(key, payload).await
+                },
+                Some(NftEvents::PolygonTransferAsset(payload)) => {
                     self.sign_permit_token_transfer_hash(key, payload).await
                 },
-                None => Ok(()),
+                Some(_) | None => Ok(()),
             },
             Services::Treasuries(key, e) => match e.event {
                 Some(TreasuryEvents::PolygonPermitTransferTokenHashSigned(p)) => {

--- a/core/proto.lock
+++ b/core/proto.lock
@@ -1,7 +1,7 @@
 [[schemas]]
 subject = "nfts"
-version = 18
-sha512 = "306c853612c1c4770c5831e6d6ee30da2a697336cf5cff105976c9e4b3bce803a68496c358226843579ce559bdeca73abb3be0c5313836c565fc72116778abe5"
+version = 19
+sha512 = "94be29cc87e02f9622ba880302349b275262bc30546e6a6daacea541a6c1c740df9a185d0e18de782eda77ebf9c51c0e46c295d89abb9f7fb725b0ce9cfaf6f1"
 
 [[schemas]]
 subject = "polygon_nfts"

--- a/core/proto.toml
+++ b/core/proto.toml
@@ -3,7 +3,7 @@ endpoint = "https://schemas.holaplex.tools"
 
 
 [schemas]
-nfts = 18
+nfts = 19
 polygon_nfts = 6
 treasury = 15
 timestamp = 1

--- a/core/src/services.rs
+++ b/core/src/services.rs
@@ -5,7 +5,7 @@ use crate::proto::{self, PolygonNftEventKey, PolygonNftEvents};
 
 #[derive(Debug)]
 pub enum Services {
-    Nfts(proto::NftEventKey, proto::PolygonEvents),
+    Nfts(proto::NftEventKey, proto::NftEvents),
     Treasuries(proto::TreasuryEventKey, proto::TreasuryEvents),
 }
 
@@ -21,7 +21,7 @@ impl hub_core::consumer::MessageGroup for Services {
         match topic {
             "hub-nfts" => {
                 let key = proto::NftEventKey::decode(key)?;
-                let val = proto::PolygonEvents::decode(val)?;
+                let val = proto::NftEvents::decode(val)?;
 
                 Ok(Services::Nfts(key, val))
             },


### PR DESCRIPTION
Nfts schema is updated to use one Events enum for both Polygon and Solana

https://github.com/holaplex/hub-nfts/pull/129
https://github.com/holaplex/hub-schema-registry/pull/60